### PR TITLE
adding programmatic bearer token generation

### DIFF
--- a/generative-ai/multimodal-ai.ipynb
+++ b/generative-ai/multimodal-ai.ipynb
@@ -43,13 +43,15 @@
    "source": [
     "# Steps\n",
     "\n",
+    "**Please check out this [YouTube video](https://www.youtube.com/watch?v=3sav6vUG_XQ) that walks you through the following set up instructions in Steps 1 and 2.**\n",
+    "\n",
     "## Step 1. Set up your environment\n",
     "\n",
     "While you can choose from several tools, this tutorial is best suited for a Jupyter Notebook. Jupyter Notebooks are widely used within data science to combine code with various data sources like text, images and data visualizations. \n",
     "\n",
     "This tutorial walks you through how to set up an IBM account to use a Jupyter Notebook.\n",
     "\n",
-    "1. Log in to [watsonx.ai](https://dataplatform.cloud.ibm.com/registration) using your IBM Cloud account.\n",
+    "1. Log in to [watsonx.ai](https://dataplatform.cloud.ibm.com/registration/stepone?context=wx&apps=all) using your IBM Cloud account.\n",
     "\n",
     "2. Create a [watsonx.ai project](https://www.ibm.com/docs/en/watsonx/saas).\n",
     "\n",
@@ -103,9 +105,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this tutorial, the API requests will require Bearer authentication. To obtain your Bearer token, please run the following commands in your terminal and insert your watsonx API key where indicated. The token will begin with \"Bearer \" and will be followed by a long string of characters. For more detailed instructions, please reference the [official documentation](https://cloud.ibm.com/docs/key-protect?topic=key-protect-retrieve-access-token).\n",
-    "\n",
-    "Note that this token expires an hour after generation. This means you will need to run the final command again once the token expires to continue with the tutorial."
+    "In this tutorial, the API requests require Bearer authentication. We can use the following function to generate our Bearer token. The token will begin with \"Bearer \" and will be followed by a long string of characters. For alternative instructions using the IBM Cloud CLI, please reference the [official documentation](https://cloud.ibm.com/docs/key-protect?topic=key-protect-retrieve-access-token). Note that this token expires an hour after generation. Hence, we will call this function within our API requests further into this tutorial to avoid errors upon token expiration."
    ]
   },
   {
@@ -114,18 +114,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# curl -fsSL https://clis.cloud.ibm.com/install/osx | sh \n",
+    "def get_bearer_token(api_key):\n",
+    "    token_endpoint = \"https://iam.cloud.ibm.com/oidc/token\"\n",
     "\n",
-    "# ibmcloud login --apikey YOUR_API_KEY_HERE\n",
+    "    payload = {\n",
+    "        \"grant_type\": \"urn:ibm:params:oauth:grant-type:apikey\",\n",
+    "        \"apikey\": api_key\n",
+    "    }\n",
     "\n",
-    "# ibmcloud iam oauth-tokens"
+    "    headers = {\n",
+    "        \"Content-Type\": \"application/x-www-form-urlencoded\"\n",
+    "    }\n",
+    "\n",
+    "    with requests.post(\n",
+    "        token_endpoint, headers=headers, data=payload\n",
+    "    ) as response:\n",
+    "        if response.status_code == 200:\n",
+    "            result = response.json()\n",
+    "            return 'Bearer ' + result['access_token']\n",
+    "        else:\n",
+    "            raise Exception('WML access failed')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once you copy your bearer token from your terminal, paste it in the following code block along with your project ID where indicated. Ensure that your `bearer_token` begins with the word \"Bearer \" and is not just a long string of characters."
+    "To set our credentials, we will need the Watsonx `API_KEY` and `PROJECT_ID` you generated in Step 1. We will also set the URL serving as the API endpoint."
    ]
   },
   {
@@ -134,11 +149,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "credentials = {\n",
-    "    \"url\": \"https://us-south.ml.cloud.ibm.com/ml/v1/text/chat?version=2023-05-29\",\n",
-    "    \"project_id\": \"YOUR_PROJECT_ID_HERE\",\n",
-    "    \"bearer_token\": \"Bearer YOUR_BEARER_TOKEN_HERE\" \n",
-    "}"
+    "API_KEY = \"YOUR_WATSONX_API_KEY_HERE\"\n",
+    "\n",
+    "PROJECT_ID = \"YOUR_WATSONX_PROJECT_ID_HERE\"\n",
+    "\n",
+    "URL = \"https://us-south.ml.cloud.ibm.com/ml/v1/text/chat?version=2023-05-29\""
    ]
   },
   {
@@ -294,7 +309,7 @@
     "    body = {\n",
     "\t\t\"messages\": [{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\": 'You are a helpful assistant. Answer the following user query in 1 or 2 sentences: ' + user_query},\n",
     "                                         {\"type\":\"image_url\",\"image_url\":{\"url\": f\"data:image/jpeg;base64,{image}\"}}]}],\n",
-    "\t\t\"project_id\": credentials.get(\"project_id\"),\n",
+    "\t\t\"project_id\": PROJECT_ID,\n",
     "\t\t\"model_id\": \"meta-llama/llama-3-2-90b-vision-instruct\",\n",
     "\t\t\"decoding_method\": \"greedy\",\n",
     "\t\t\"repetition_penalty\": 1,\n",
@@ -302,26 +317,6 @@
     "\t}\n",
     "\n",
     "    return body"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Next, we can establish the headers of our API requests. This will remain unchanged throughout the tutorial. The headers provide the API with the request's metadata."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "headers = {\n",
-    "\t\"Accept\": \"application/json\",\n",
-    "\t\"Content-Type\": \"application/json\",\n",
-    "\t\"Authorization\": credentials.get(\"bearer_token\")\n",
-    "}"
    ]
   },
   {
@@ -358,8 +353,12 @@
     "\trequest_body = augment_api_request_body(user_query, image)\n",
     "\n",
     "\tresponse = requests.post(\n",
-    "\t\tcredentials.get(\"url\"),\n",
-    "\t\theaders=headers,\n",
+    "\t\tURL,\n",
+    "\t\theaders= {\n",
+    "\t\t\t\"Accept\": \"application/json\",\n",
+    "\t\t\t\"Content-Type\": \"application/json\",\n",
+    "\t\t\t\"Authorization\": get_bearer_token(API_KEY)\n",
+    "\t\t},\n",
     "\t\tjson=request_body\n",
     "\t)\n",
     "\n",
@@ -408,10 +407,14 @@
     "request_body = augment_api_request_body(user_query, image)\n",
     "\n",
     "response = requests.post(\n",
-    "\tcredentials.get(\"url\"),\n",
-    "\theaders=headers,\n",
-    "\tjson=request_body\n",
-    ")\n",
+    "\t\tURL,\n",
+    "\t\theaders= {\n",
+    "\t\t\t\"Accept\": \"application/json\",\n",
+    "\t\t\t\"Content-Type\": \"application/json\",\n",
+    "\t\t\t\"Authorization\": get_bearer_token(API_KEY)\n",
+    "\t\t},\n",
+    "\t\tjson=request_body\n",
+    "\t)\n",
     "\n",
     "if response.status_code != 200:\n",
     "\traise Exception(\"Non-200 response: \" + str(response.text))\n",
@@ -449,10 +452,14 @@
     "body = augment_api_request_body(user_query, image)\n",
     "\n",
     "response = requests.post(\n",
-    "\tcredentials.get(\"url\"),\n",
-    "\theaders=headers,\n",
-    "\tjson=body\n",
-    ")\n",
+    "\t\tURL,\n",
+    "\t\theaders= {\n",
+    "\t\t\t\"Accept\": \"application/json\",\n",
+    "\t\t\t\"Content-Type\": \"application/json\",\n",
+    "\t\t\t\"Authorization\": get_bearer_token(API_KEY)\n",
+    "\t\t},\n",
+    "\t\tjson=request_body\n",
+    "\t)\n",
     "\n",
     "if response.status_code != 200:\n",
     "\traise Exception(\"Non-200 response: \" + str(response.text))\n",
@@ -492,10 +499,14 @@
     "body = augment_api_request_body(user_query, image)\n",
     "\n",
     "response = requests.post(\n",
-    "\tcredentials.get(\"url\"),\n",
-    "\theaders=headers,\n",
-    "\tjson=body\n",
-    ")\n",
+    "\t\tURL,\n",
+    "\t\theaders= {\n",
+    "\t\t\t\"Accept\": \"application/json\",\n",
+    "\t\t\t\"Content-Type\": \"application/json\",\n",
+    "\t\t\t\"Authorization\": get_bearer_token(API_KEY)\n",
+    "\t\t},\n",
+    "\t\tjson=request_body\n",
+    "\t)\n",
     "\n",
     "if response.status_code != 200:\n",
     "\traise Exception(\"Non-200 response: \" + str(response.text))\n",

--- a/generative-ai/multimodal-ai.ipynb
+++ b/generative-ai/multimodal-ai.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Use Llama 3.2-90b-vision-instruct for multimodal AI queries in Python with watsonx\n",
     "\n",
-    "**Authors:** Anna Gutowska, Erika Russi, N.A.B.\n",
+    "**Authors:** Anna Gutowska, Erika Russi, Jess Bozorg\n",
     "\n",
     "In this tutorial, you will discover how to apply the [Meta Llama 3.2-90b-vision-instruct](https://www.llama.com/) model now available on [watsonx.ai](https://www.ibm.com/products/watsonx-ai) to [computer vision](https://www.ibm.com/topics/computer-vision) tasks such as image captioning and visual question answering. \n",
     "\n",
@@ -97,6 +97,7 @@
     "#imports\n",
     "import requests\n",
     "import base64\n",
+    "import datetime \n",
     "\n",
     "from PIL import Image"
    ]
@@ -105,7 +106,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this tutorial, the API requests require Bearer authentication. We can use the following function to generate our Bearer token. The token will begin with \"Bearer \" and will be followed by a long string of characters. For alternative instructions using the IBM Cloud CLI, please reference the [official documentation](https://cloud.ibm.com/docs/key-protect?topic=key-protect-retrieve-access-token). Note that this token expires an hour after generation. Hence, we will call this function within our API requests further into this tutorial to avoid errors upon token expiration."
+    "In this tutorial, the API requests require Bearer authentication. We can use the following function to generate our Bearer token. The token will begin with \"Bearer \" and will be followed by a long string of characters. For alternative instructions using the IBM Cloud CLI, please reference the [official documentation](https://cloud.ibm.com/docs/key-protect?topic=key-protect-retrieve-access-token). Note that this token expires an hour after generation. "
    ]
   },
   {
@@ -115,6 +116,7 @@
    "outputs": [],
    "source": [
     "def get_bearer_token(api_key):\n",
+    "    \n",
     "    token_endpoint = \"https://iam.cloud.ibm.com/oidc/token\"\n",
     "\n",
     "    payload = {\n",
@@ -154,6 +156,24 @@
     "PROJECT_ID = \"YOUR_WATSONX_PROJECT_ID_HERE\"\n",
     "\n",
     "URL = \"https://us-south.ml.cloud.ibm.com/ml/v1/text/chat?version=2023-05-29\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Given the `API_KEY`, we can generate a bearer token using the `get_bearer_token` function and create a variable to store the time at which the token was generated. We will use this variable to assess whether the token has expired since the token expires every 60 minutes. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bearer_token = get_bearer_token(API_KEY)\n",
+    "\n",
+    "bearer_generated_time = datetime.datetime.now()"
    ]
   },
   {
@@ -325,7 +345,9 @@
    "source": [
     "## Step 6. Image captioning\n",
     "\n",
-    "Now, we can loop through our images to see the text descriptions produced by the model in response to the query, \"What is happening in this image?\""
+    "Now, we can loop through our images to see the text descriptions produced by the model in response to the query, \"What is happening in this image?\"\n",
+    "\n",
+    "In each iteration of this loop, we compare the time now and the time of the bearer token creation. We do this because the token expires every 60 minutes. If enough time has passed for the token to expire, we generate a new one. "
    ]
   },
   {
@@ -337,10 +359,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The image depicts a bustling city street, with cars and pedestrians navigating through the scene. The street is lined with tall buildings and trees, creating a vibrant urban atmosphere.\n",
-      "The image depicts a woman in athletic attire running down the street, with a building featuring a parking lot and garage doors visible in the background. The scene suggests that the woman is engaging in a morning or evening jog, taking advantage of the empty streets to exercise and clear her mind.\n",
-      "The image depicts a house and farm buildings surrounded by floodwaters, with the water level reaching the roofs of the structures. The presence of the floodwaters suggests that the area has experienced heavy rainfall or a natural disaster, resulting in the flooding of the property.\n",
-      "The image shows a person's finger pointing to the nutrition facts label on a food package. The label displays information about the serving size, calories, and nutritional content of the product.\n"
+      "The image shows a bustling city street with tall buildings and a busy intersection. The scene is set in the daytime, with people walking on the sidewalk and cars driving down the street.\n",
+      "This image shows a woman running on the street. She is wearing a yellow hoodie, black capri leggings, and black sneakers.\n",
+      "**Scene Description**\n",
+      "\n",
+      "* The image depicts a flooded area of farmland, with water surrounding several buildings.\n",
+      "* The buildings appear to be partially or fully submerged in the water.\n",
+      "**Image Description**\n",
+      "\n",
+      "* The image shows a hand holding a nutrition label, with the individual's index finger pointing to the label.\n",
+      "* The label appears to be from a food product, displaying information about its nutritional content.\n"
      ]
     }
    ],
@@ -351,13 +379,19 @@
     "\tuser_query = \"What is happening in this image?\"\n",
     "\t\n",
     "\trequest_body = augment_api_request_body(user_query, image)\n",
+    "\t\n",
+    "\tdiff = datetime.datetime.now() - bearer_generated_time \n",
+    "\n",
+    "\tif diff.seconds > 3600:\n",
+    "\t\tbearer_generated_time = datetime.datetime.now()\n",
+    "\t\tbearer_token = get_bearer_token(API_KEY)\n",
     "\n",
     "\tresponse = requests.post(\n",
     "\t\tURL,\n",
     "\t\theaders= {\n",
     "\t\t\t\"Accept\": \"application/json\",\n",
     "\t\t\t\"Content-Type\": \"application/json\",\n",
-    "\t\t\t\"Authorization\": get_bearer_token(API_KEY)\n",
+    "\t\t\t\"Authorization\": bearer_token\n",
     "\t\t},\n",
     "\t\tjson=request_body\n",
     "\t)\n",
@@ -406,12 +440,18 @@
     "\n",
     "request_body = augment_api_request_body(user_query, image)\n",
     "\n",
+    "diff = datetime.datetime.now() - bearer_generated_time \n",
+    "\n",
+    "if diff.seconds > 3600:\n",
+    "\tbearer_generated_time = datetime.datetime.now()\n",
+    "\tbearer_token = get_bearer_token(API_KEY)\n",
+    "\n",
     "response = requests.post(\n",
     "\t\tURL,\n",
     "\t\theaders= {\n",
     "\t\t\t\"Accept\": \"application/json\",\n",
     "\t\t\t\"Content-Type\": \"application/json\",\n",
-    "\t\t\t\"Authorization\": get_bearer_token(API_KEY)\n",
+    "\t\t\t\"Authorization\": bearer_token\n",
     "\t\t},\n",
     "\t\tjson=request_body\n",
     "\t)\n",
@@ -451,12 +491,18 @@
     "\n",
     "body = augment_api_request_body(user_query, image)\n",
     "\n",
+    "diff = datetime.datetime.now() - bearer_generated_time \n",
+    "\n",
+    "if diff.seconds > 3600:\n",
+    "\tbearer_generated_time = datetime.datetime.now()\n",
+    "\tbearer_token = get_bearer_token(API_KEY)\n",
+    "\t\n",
     "response = requests.post(\n",
     "\t\tURL,\n",
     "\t\theaders= {\n",
     "\t\t\t\"Accept\": \"application/json\",\n",
     "\t\t\t\"Content-Type\": \"application/json\",\n",
-    "\t\t\t\"Authorization\": get_bearer_token(API_KEY)\n",
+    "\t\t\t\"Authorization\": bearer_token\n",
     "\t\t},\n",
     "\t\tjson=request_body\n",
     "\t)\n",
@@ -498,12 +544,18 @@
     "\n",
     "body = augment_api_request_body(user_query, image)\n",
     "\n",
+    "diff = datetime.datetime.now() - bearer_generated_time \n",
+    "\n",
+    "if diff.seconds > 3600:\n",
+    "\tbearer_token = get_bearer_token(API_KEY)\n",
+    "\tbearer_generated_time = datetime.datetime.now()\n",
+    "\n",
     "response = requests.post(\n",
     "\t\tURL,\n",
     "\t\theaders= {\n",
     "\t\t\t\"Accept\": \"application/json\",\n",
     "\t\t\t\"Content-Type\": \"application/json\",\n",
-    "\t\t\t\"Authorization\": get_bearer_token(API_KEY)\n",
+    "\t\t\t\"Authorization\": bearer_token\n",
     "\t\t},\n",
     "\t\tjson=request_body\n",
     "\t)\n",


### PR DESCRIPTION
No longer does the reader need to generate the bearer token through the CLI, now it can be done programmatically and without expiration errors. 

This change was implemented due to feedback from IBMers running the code for their own projects. 